### PR TITLE
chore: migrate agent state path convention .agents/ -> .workspace/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 
 # Codex — local config and dev state
 .codex/
-.agents/backlog/
-.agents/transitions/
+.workspace/backlog/
+.workspace/transitions/
 
 # MCP — local server config
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,4 +16,4 @@ Agent infrastructure in this repo:
 
 - Claude config: `.claude/CLAUDE.md` and `.claude/settings.json`
 - Codex/OpenAI config: `AGENTS.md`
-- There is no repo-local `.agents/` directory checked in here.
+- There is no repo-local `.workspace/` directory checked in here.


### PR DESCRIPTION
Interop convention: shared Claude+Codex state lives in .workspace/,
reserving .agents/ for Codex-native skills. Config path rewrites only.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
